### PR TITLE
don't parse eval URLs after captureJSCallUsage. parse all others.

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -101,6 +101,7 @@ function dateNowTest() {
   }
   helloDate();
   eval('Date.now()'); // FAIL
+  new Function('Date.now()')() // FAIL
 }
 
 function consoleTimeTest() {

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -60,17 +60,7 @@ class NoConsoleTimeAudit extends Audit {
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
-      let result = err.url;
-
-      if (!err.isEval) {
-        try {
-          result = new URL(err.url).host === pageHost;
-        } catch (err) {
-          result = false;
-        }
-      }
-
-      return result;
+      return err.isEval ? err.url : new URL(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -60,7 +60,7 @@ class NoConsoleTimeAudit extends Audit {
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
-      return err.isEval ? err.url : new URL(err.url).host === pageHost;
+      return err.isEval ? !!err.url : new URL(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -61,7 +61,7 @@ class NoDateNowAudit extends Audit {
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.DateNowUse.usage.filter(err => {
-      return err.isEval ? err.url : new URL(err.url).host === pageHost;
+      return err.isEval ? !!err.url : new URL(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -61,17 +61,7 @@ class NoDateNowAudit extends Audit {
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.DateNowUse.usage.filter(err => {
-      let result = err.url;
-
-      if (!err.isEval) {
-        try {
-          result = new URL(err.url).host === pageHost;
-        } catch (err) {
-          result = false;
-        }
-      }
-
-      return result;
+      return err.isEval ? err.url : new URL(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -76,12 +76,12 @@ describe('Page does not use console.time()', () => {
         usage: [
           {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
           {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
-          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: false}
+          {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
         ]
       },
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.equal(auditResult.extendedInfo.value.length, 3);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -91,12 +91,12 @@ describe('Page does not use Date.now()', () => {
         usage: [
           {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
           {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
-          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: false}
+          {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
         ]
       },
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.equal(auditResult.extendedInfo.value.length, 3);
   });
 });


### PR DESCRIPTION
This PR's destination is PR #997 (Add whatwg-url parser to parse our urls)

The unit tests provide nonparsable urls that appear to come from `eval()` however they were tagged as `isEval: false`, which doesn't make sense.

I think we can trust the V8 Stack Trace API to correctly tag the `isEval` property, so i've adjusted those test fixtures. This allows us to nuke the ugly try/catch on parsing.

@ebidel does this work for you?